### PR TITLE
Fix std::min type mismatch on macOS and unify uint64 usage

### DIFF
--- a/src/engine.h
+++ b/src/engine.h
@@ -180,7 +180,7 @@ public:
 
 	typedef size_t Reg;
 
-	virtual void set(const Reg dst, const size_t a) const = 0;
+	virtual void set(const Reg dst, const uint64 a) const = 0;
 	virtual void get(uint64 * const d, const Reg src) const = 0;
 	virtual void copy(const Reg dst, const Reg src) const = 0;
 	virtual bool is_equal(const Reg src1, const Reg src2) const = 0;

--- a/src/ocl.h
+++ b/src/ocl.h
@@ -310,7 +310,7 @@ public:
 public:
 	size_t get_max_workgroup_size() const { return _max_workgroup_size; }
 	size_t get_local_mem_size() const { return _local_mem_size; }
-	size_t get_max_local_worksize(const size_t type_size) const { return std::min(_max_workgroup_size, _local_mem_size / type_size); }
+	size_t get_max_local_worksize(const size_t type_size) const { return std::min(static_cast<size_t>(_max_workgroup_size), static_cast<size_t>(_local_mem_size / type_size)); }
 	size_t get_timer_resolution() const { return _timer_resolution; }
 	bool isIntel() const { return (_vendor == EVendor::INTEL); }
 


### PR DESCRIPTION
Fix macOS build issues and unify uint64 usage
This PR fixes a std::min type mismatch on macOS and replaces a size_t parameter with uint64 for consistency across implementations.