### PR TITLE
OpenCL: avoid Apple reserved typedefs (uint32/int32), add macOS makefile

### DIFF
--- a/makefile_macosx
+++ b/makefile_macosx
@@ -1,0 +1,43 @@
+CC = g++ -m64 -std=c++20
+
+BIN_DIR = .
+SRC_DIR = src
+
+OCL_INC = -IKhronos
+OCL_LIB = -framework OpenCL
+
+CFLAGS = -Wall -Wextra -Wsign-conversion -ffinite-math-only
+FLAGS_CPU = -O3
+FLAGS_GPU = -O2 -DGPU
+
+OBJS_CPU = marinc.o cpu.o
+OBJS_GPU = maring.o gpu.o
+
+DEPS = $(SRC_DIR)/engine.h $(SRC_DIR)/arith.h
+DEPS_MERS = $(SRC_DIR)/mersenne.h $(SRC_DIR)/ibdwt.h $(SRC_DIR)/file.h
+
+EXEC_CPU = $(BIN_DIR)/marin_cpu
+EXEC_GPU = $(BIN_DIR)/marin
+
+build: $(EXEC_CPU) $(EXEC_GPU)
+
+marinc.o: $(SRC_DIR)/marin.cpp $(DEPS) $(DEPS_MERS)
+	$(CC) $(CFLAGS) $(FLAGS_CPU) -c $< -o $@
+
+maring.o: $(SRC_DIR)/marin.cpp $(DEPS) $(DEPS_MERS) $(SRC_DIR)/ocl.h
+	$(CC) $(CFLAGS) $(FLAGS_GPU) $(OCL_INC) -c $< -o $@
+
+cpu.o: $(SRC_DIR)/cpu.cpp $(DEPS) $(SRC_DIR)/engine_cpu.h
+	$(CC) $(CFLAGS) $(FLAGS_CPU) -c $< -o $@
+
+gpu.o: $(SRC_DIR)/gpu.cpp $(DEPS) $(SRC_DIR)/engine_gpu.h $(SRC_DIR)/ocl.h
+	$(CC) $(CFLAGS) $(FLAGS_GPU) $(OCL_INC) -c $< -o $@
+
+$(EXEC_CPU): $(OBJS_CPU)
+	$(CC) $(FLAGS_CPU) $^ -lgmp -o $@
+
+$(EXEC_GPU): $(OBJS_GPU)
+	$(CC) $(FLAGS_GPU) $^ -lgmp $(OCL_LIB) -o $@
+
+clean:
+	rm -f $(OBJS_CPU) $(OBJS_GPU) $(EXEC_CPU) $(EXEC_GPU)

--- a/ocl/kernel.cl
+++ b/ocl/kernel.cl
@@ -38,14 +38,22 @@ Please give feedback to the authors if improvement is realized. It is distribute
 #define MAX_WG_SZ	256
 #endif
 
-typedef uint	sz_t;
-typedef uchar	uint_8;
-typedef uint	uint32;
-typedef int		int32;
-typedef ulong	uint64;
-typedef uchar4	uint_8_4;
-typedef ulong2	uint64_2;
-typedef ulong4	uint64_4;
+typedef uchar  u8;
+typedef uint   u32;
+typedef int    s32;
+typedef ulong  u64;
+typedef uchar4 u8x4;
+typedef ulong2 u64x2;
+typedef ulong4 u64x4;
+typedef u32    sz_t;
+
+#define uint_8    u8
+#define uint32    u32
+#define int32     s32
+#define uint64    u64
+#define uint_8_4  u8x4
+#define uint64_2  u64x2
+#define uint64_4  u64x4
 
 INLINE sz_t div5(const sz_t n) { return mul_hi(n, 858993460u); }	// = n / 5 if n < 2^30
 

--- a/src/ocl/kernel.h
+++ b/src/ocl/kernel.h
@@ -50,14 +50,22 @@ static const char * const src_ocl_kernel = \
 "#define MAX_WG_SZ	256\n" \
 "#endif\n" \
 "\n" \
-"typedef uint	sz_t;\n" \
-"typedef uchar	uint_8;\n" \
-"typedef uint	uint32;\n" \
-"typedef int		int32;\n" \
-"typedef ulong	uint64;\n" \
-"typedef uchar4	uint_8_4;\n" \
-"typedef ulong2	uint64_2;\n" \
-"typedef ulong4	uint64_4;\n" \
+"typedef uchar  u8;\n" \
+"typedef uint   u32;\n" \
+"typedef int    s32;\n" \
+"typedef ulong  u64;\n" \
+"typedef uchar4 u8x4;\n" \
+"typedef ulong2 u64x2;\n" \
+"typedef ulong4 u64x4;\n" \
+"typedef u32    sz_t;\n" \
+"\n" \
+"#define uint_8    u8\n" \
+"#define uint32    u32\n" \
+"#define int32     s32\n" \
+"#define uint64    u64\n" \
+"#define uint_8_4  u8x4\n" \
+"#define uint64_2  u64x2\n" \
+"#define uint64_4  u64x4\n" \
 "\n" \
 "INLINE sz_t div5(const sz_t n) { return mul_hi(n, 858993460u); }	// = n / 5 if n < 2^30\n" \
 "\n" \


### PR DESCRIPTION
OpenCL: avoid Apple reserved typedefs (uint32/int32), add macOS makefile